### PR TITLE
torch_dist_run.py增加指定显卡编号逻辑

### DIFF
--- a/torch_dist_run.py
+++ b/torch_dist_run.py
@@ -98,12 +98,21 @@ if __name__ == '__main__':
         type=int,
         help='Port to use for distributed training'
     )
+    parser.add_argument(
+        '--cuda_devices', '-c',
+        default=None,
+        type=str,
+        help='CUDA devices to use, e.g., "0,1,2"'
+    )
 
     args, unknown = parser.parse_known_args()
     argv = ' '.join(unknown)
 
     unique_job_name = args.main_file + argv
     os.environ['MASTER_PORT'] = str(args.port)
+
+    if args.cuda_devices:
+        os.environ['CUDA_VISIBLE_DEVICES'] = args.cuda_devices
 
     auto_dist_run(
         main_file=args.main_file,


### PR DESCRIPTION
Time-MoE的开发者您好，我在自己的多卡电脑上研究time moe的微调时，在0号显卡空闲，1号显卡跑了一个其他训练任务的情况下执行微调任务，代码报错1号显卡显存不够，然后我尝试着解决了一下这个问题，在torch_dist_run.py中增加了指定本机可用的显卡编号的功能，通过命令行参数--cuda_devices来设置，避免了在单机多卡微调时，由于某个显卡不可用导致程序退出的问题。