### PR TITLE
Support transformers >= 4.40.0 (including 4.57.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pandas
 torch
 scikit-learn
 
-transformers==4.40.1
-datasets==2.18.0
-accelerate==0.28.0
+transformers>=4.40.0
+datasets>=2.18.0
+accelerate>=0.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pandas
 torch
 scikit-learn
 
-transformers>=4.40.0
+transformers>=4.57.0
 datasets>=2.18.0
 accelerate>=0.28.0

--- a/run_eval.py
+++ b/run_eval.py
@@ -51,22 +51,23 @@ class MAEMetric(SumEvalMetric):
 
 
 class TimeMoE:
-    def __init__(self, model_path, device, context_length, prediction_length, **kwargs):
+    def __init__(self, model_path, device, context_length, prediction_length, cache_dir=None, **kwargs):
+        self.cache_dir = cache_dir
         try:
             from time_moe.models.modeling_time_moe import TimeMoeForPrediction
             model = TimeMoeForPrediction.from_pretrained(
                 model_path,
                 device_map=device,
-                # attn_implementation='flash_attention_2',
                 torch_dtype='auto',
+                cache_dir=cache_dir,
             )
         except:
             model = AutoModelForCausalLM.from_pretrained(
                 model_path,
                 device_map=device,
-                # attn_implementation='flash_attention_2',
                 torch_dtype='auto',
                 trust_remote_code=True,
+                cache_dir=cache_dir,
             )
 
         logging.info(f'>>> Model dtype: {model.dtype}; Attention:{model.config._attn_implementation}')
@@ -111,6 +112,9 @@ def evaluate(args):
             print('Error: ', f'Setup nccl fail, so set device to cpu: {e}')
             device = 'cpu'
             is_dist = False
+    elif torch.backends.mps.is_available():
+        device = 'mps'
+        is_dist = False
     else:
         device = 'cpu'
         is_dist = False
@@ -125,7 +129,8 @@ def evaluate(args):
         args.model,
         device,
         context_length=context_length,
-        prediction_length=prediction_length
+        prediction_length=prediction_length,
+        cache_dir=args.cache_dir,
     )
     if args.data.endswith('.csv'):
         dataset = BenchmarkEvalDataset(
@@ -223,6 +228,12 @@ if __name__ == '__main__':
         type=int,
         default=96,
         help='Prediction length'
+    )
+    parser.add_argument(
+        '--cache_dir',
+        type=str,
+        default=None,
+        help='Cache directory for model weights'
     )
     args = parser.parse_args()
     if args.context_length is None:

--- a/time_moe/models/modeling_time_moe.py
+++ b/time_moe/models/modeling_time_moe.py
@@ -411,7 +411,7 @@ class TimeMoeAttention(nn.Module):
                     "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
                     "with a layer index."
                 )
-            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+            kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
 
@@ -506,7 +506,7 @@ class TimeMoeFlashAttention2(TimeMoeAttention):
                     "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
                     "with a layer index."
                 )
-            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+            kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
         rotary_seq_len = max(kv_seq_len, position_ids[:, -1].max().item()) + 1
         cos, sin = self.rotary_emb(value_states, seq_len=rotary_seq_len)
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
@@ -822,7 +822,7 @@ class TimeMoeModel(TimeMoePreTrainedModel):
             use_legacy_cache = not isinstance(past_key_values, Cache)
             if use_legacy_cache:
                 past_key_values = DynamicCache.from_legacy_cache(past_key_values)
-            past_key_values_length = past_key_values.get_usable_length(seq_length)
+            past_key_values_length = past_key_values.get_seq_length()
 
         if position_ids is None:
             device = input_ids.device if input_ids is not None else inputs_embeds.device
@@ -1108,16 +1108,11 @@ class TimeMoeForPrediction(TimeMoePreTrainedModel, TSGenerationMixin):
     def prepare_inputs_for_generation(
             self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
     ):
-        # Omit tokens covered by past_key_values
         if past_key_values is not None:
             if isinstance(past_key_values, Cache):
                 cache_length = past_key_values.get_seq_length()
-                if isinstance(past_key_values, DynamicCache):
-                    past_length = past_key_values.seen_tokens
-                else:
-                    past_length = cache_length
-
-                max_cache_length = past_key_values.get_max_length()
+                past_length = cache_length
+                max_cache_length = getattr(past_key_values, 'max_cache_len', None)
             else:
                 cache_length = past_length = past_key_values[0][0].shape[2]
                 max_cache_length = None

--- a/time_moe/models/ts_generation_mixin.py
+++ b/time_moe/models/ts_generation_mixin.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import torch
 
-from transformers import GenerationMixin, LogitsProcessorList, StoppingCriteriaList
+from transformers import GenerationMixin, LogitsProcessorList, StoppingCriteriaList, GenerationConfig
 from transformers.generation import validate_stopping_criteria, EosTokenCriteria
 from transformers.generation.utils import GenerateNonBeamOutput, GenerateEncoderDecoderOutput, GenerateDecoderOnlyOutput
 from transformers.utils import ModelOutput
@@ -11,83 +11,46 @@ from transformers.utils import ModelOutput
 
 class TSGenerationMixin(GenerationMixin):
 
-    def _greedy_search(
+    def _sample(
             self,
-            input_ids: torch.Tensor,
-            logits_processor: Optional[LogitsProcessorList] = None,
-            stopping_criteria: Optional[StoppingCriteriaList] = None,
-            max_length: Optional[int] = None,
-            pad_token_id: Optional[int] = None,
-            eos_token_id: Optional[Union[int, List[int]]] = None,
-            output_attentions: Optional[bool] = None,
-            output_hidden_states: Optional[bool] = None,
-            output_scores: Optional[bool] = None,
-            output_logits: Optional[bool] = None,
-            return_dict_in_generate: Optional[bool] = None,
+            input_ids: torch.LongTensor,
+            logits_processor: LogitsProcessorList,
+            stopping_criteria: StoppingCriteriaList,
+            generation_config: GenerationConfig,
             synced_gpus: bool = False,
             streamer: Optional["BaseStreamer"] = None,
             **model_kwargs,
-    ) -> Union[GenerateNonBeamOutput, torch.Tensor]:
+    ) -> Union[GenerateNonBeamOutput, torch.LongTensor]:
         input_ids_origin_device = input_ids.device
         input_ids = input_ids.to(self.device)
         if len(input_ids.shape) == 2:
             batch_size, cur_len = input_ids.shape
         else:
             raise ValueError('Input shape must be: [batch_size, seq_len]')
-        # init values
-        logits_processor = logits_processor if logits_processor is not None else LogitsProcessorList()
-        stopping_criteria = stopping_criteria if stopping_criteria is not None else StoppingCriteriaList()
-        if max_length is not None:
-            warnings.warn(
-                "`max_length` is deprecated in this function, use"
-                " `stopping_criteria=StoppingCriteriaList([MaxLengthCriteria(max_length=max_length)])` instead.",
-                UserWarning,
-            )
-            stopping_criteria = validate_stopping_criteria(stopping_criteria, max_length)
-        pad_token_id = pad_token_id if pad_token_id is not None else self.generation_config.pad_token_id
-        if eos_token_id is not None:
-            stopping_criteria.append(EosTokenCriteria(eos_token_id=eos_token_id))
-        else:
-            # remove when the method is totally private
-            # need to get `eos_token_id` and add stopping criteria, so that generation does not go forever
-            eos_token_id = [
-                criteria.eos_token_id.tolist() for criteria in stopping_criteria if hasattr(criteria, "eos_token_id")
-            ]
-            eos_token_id = eos_token_id[0] if eos_token_id else None
-            if eos_token_id is None and self.generation_config.eos_token_id is not None:
-                eos_token_id = self.generation_config.eos_token_id
-                stopping_criteria.append(EosTokenCriteria(eos_token_id=eos_token_id))
-
+        
+        pad_token_id = generation_config._pad_token_tensor
+        output_attentions = generation_config.output_attentions
+        output_hidden_states = generation_config.output_hidden_states
+        output_scores = generation_config.output_scores
+        output_logits = generation_config.output_logits
+        return_dict_in_generate = generation_config.return_dict_in_generate
+        
+        eos_token_id = generation_config._eos_token_tensor
         if isinstance(eos_token_id, int):
             eos_token_id = [eos_token_id]
-        output_scores = output_scores if output_scores is not None else self.generation_config.output_scores
-        output_attentions = (
-            output_attentions if output_attentions is not None else self.generation_config.output_attentions
-        )
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.generation_config.output_hidden_states
-        )
-        return_dict_in_generate = (
-            return_dict_in_generate
-            if return_dict_in_generate is not None
-            else self.generation_config.return_dict_in_generate
-        )
 
-        # init attention / hidden states / scores tuples
         raw_logits = () if (return_dict_in_generate and output_logits) else None
         scores = () if (return_dict_in_generate and output_scores) else None
         decoder_attentions = () if (return_dict_in_generate and output_attentions) else None
         cross_attentions = () if (return_dict_in_generate and output_attentions) else None
         decoder_hidden_states = () if (return_dict_in_generate and output_hidden_states) else None
 
-        # if model is an encoder-decoder, retrieve encoder attention weights and hidden states
         if return_dict_in_generate and self.config.is_encoder_decoder:
             encoder_attentions = model_kwargs["encoder_outputs"].get("attentions") if output_attentions else None
             encoder_hidden_states = (
                 model_kwargs["encoder_outputs"].get("hidden_states") if output_hidden_states else None
             )
 
-        # keep track of which sequences are already finished
         if "inputs_embeds" in model_kwargs:
             cur_len = model_kwargs["inputs_embeds"].shape[1]
         this_peer_finished = False
@@ -96,12 +59,10 @@ class TSGenerationMixin(GenerationMixin):
 
         max_length = stopping_criteria.max_length
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
-            # prepare model inputs
             model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
 
             input_length = input_ids.shape[1]
 
-            # forward pass to get next token
             outputs = self(
                 **model_inputs,
                 return_dict=True,
@@ -111,14 +72,12 @@ class TSGenerationMixin(GenerationMixin):
             )
 
             if synced_gpus and this_peer_finished:
-                continue  # don't waste resources running the code we don't need
+                continue
 
             next_token_logits = outputs.logits[:, -1, :]
 
-            # pre-process distribution
             next_tokens_scores = logits_processor(input_ids, next_token_logits)
 
-            # Store scores, attentions and hidden_states when required
             if return_dict_in_generate:
                 if output_scores:
                     scores += (next_tokens_scores,)
@@ -138,20 +97,18 @@ class TSGenerationMixin(GenerationMixin):
                         else (outputs.hidden_states,)
                     )
 
-            # argmax
-            # next_tokens = torch.argmax(next_tokens_scores, dim=-1)
             next_tokens = next_tokens_scores
 
-            # finished sentences should have their next token be a padding token
             if eos_token_id is not None:
                 if pad_token_id is None:
                     raise ValueError("If `eos_token_id` is defined, make sure that `pad_token_id` is defined.")
                 next_tokens = next_tokens * unfinished_sequences + pad_token_id * (1 - unfinished_sequences)
 
-            # update generated ids, model inputs, and length for next step
             next_tokens = next_tokens.reshape(batch_size, -1, self.config.input_size)
             horizon_length = next_tokens.shape[1]
 
+            if input_ids.ndim == 2:
+                input_ids = input_ids.unsqueeze(-1)
             input_ids = torch.cat([input_ids, next_tokens], dim=-2)
             if streamer is not None:
                 streamer.put(next_tokens.cpu())
@@ -205,27 +162,21 @@ class TSGenerationMixin(GenerationMixin):
             is_encoder_decoder: bool = False,
             standardize_cache_format: bool = False,
     ) -> Dict[str, Any]:
-        # update past_key_values
-        model_kwargs["past_key_values"] = self._extract_past_from_model_output(
-            outputs, standardize_cache_format=standardize_cache_format
-        )
+        model_kwargs["past_key_values"] = outputs.past_key_values
         if getattr(outputs, "state", None) is not None:
             model_kwargs["state"] = outputs.state
 
-        # update token_type_ids with last value
         if "token_type_ids" in model_kwargs:
             token_type_ids = model_kwargs["token_type_ids"]
             model_kwargs["token_type_ids"] = torch.cat([token_type_ids, token_type_ids[:, -1].unsqueeze(-1)], dim=-1)
 
         if not is_encoder_decoder:
-            # update attention mask
             if "attention_mask" in model_kwargs:
                 attention_mask = model_kwargs["attention_mask"]
                 model_kwargs["attention_mask"] = torch.cat(
                     [attention_mask, attention_mask.new_ones((attention_mask.shape[0], horizon_length))], dim=-1
                 )
         else:
-            # update decoder attention mask
             if "decoder_attention_mask" in model_kwargs:
                 decoder_attention_mask = model_kwargs["decoder_attention_mask"]
                 model_kwargs["decoder_attention_mask"] = torch.cat(
@@ -235,6 +186,5 @@ class TSGenerationMixin(GenerationMixin):
 
         if "cache_position" in model_kwargs and model_kwargs["cache_position"] is not None:
             model_kwargs["cache_position"] = model_kwargs["cache_position"][-1:] + horizon_length
-            # model_kwargs["cache_position"] = model_kwargs["cache_position"][-1:] + 1
 
         return model_kwargs


### PR DESCRIPTION
This PR adds compatibility with newer versions of transformers (>= 4.40.0).

Changes:
- Replace deprecated  with  in Cache API
- Remove usage of  attribute (removed in newer transformers)
- Replace  with  attribute
- Replace deprecated  with direct access to
- Add MPS device support for Apple Silicon
- Add  argument for specifying model cache directory
- Update requirements.txt to use >= version constraints

Tested with transformers 4.57.0 on both CPU and MPS devices.